### PR TITLE
Add store in s3 operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -24,4 +24,5 @@ from .input_operator import InputOperator
 from .output_operator import OutputOperator
 from .vectorize import VectorizeOperator
 from .store_in_db import StoreInDb
+from .store_in_s3 import StoreInS3
 from .text_search_in_db import TextSearchInDb

--- a/operators/store_in_s3.py
+++ b/operators/store_in_s3.py
@@ -1,4 +1,5 @@
 import os
+import json
 import boto3
 import requests
 from urllib.parse import urlparse
@@ -98,11 +99,7 @@ class StoreInS3(BaseOperator):
         ai_context: AiContext
     ):
         # Get AWS credentials
-        aws_credentials = {
-            'aws_access_key_id': ai_context.get_secret('aws_access_key_id'),
-            'aws_secret_access_key': ai_context.get_secret('aws_secret_access_key'),
-            'aws_region_name': ai_context.get_secret('aws_region_name')
-        }
+        aws_credentials = json.loads(ai_context.get_secret('aws_credentials'))
 
         # Parse inputs
         file_url = ai_context.get_input('file_url', self)

--- a/operators/store_in_s3.py
+++ b/operators/store_in_s3.py
@@ -1,0 +1,127 @@
+import os
+import boto3
+import requests
+from urllib.parse import urlparse
+from botocore.exceptions import ClientError
+
+from .base_operator import BaseOperator
+
+from ai_context import AiContext
+
+
+class StoreInS3(BaseOperator):
+    @staticmethod
+    def declare_name():
+        return 'Store in S3'
+    
+    @staticmethod
+    def declare_category():
+        return BaseOperator.OperatorCategory.DB.value
+    
+    @staticmethod    
+    def declare_parameters():
+        return [
+            {
+                "name": "file_name",
+                "data_type": "string",
+                "placeholder": "File name (object key) that will be stored in S3",
+            },
+            {
+                "name": "s3_bucket",
+                "data_type": "string",
+                "placeholder": "S3 bucket name",
+            },            
+            {
+                "name": "overwrite",
+                "data_type": "boolean"
+            }
+        ]
+    
+    @staticmethod    
+    def declare_inputs():
+        return [
+            {
+                "name": "file_url",
+                "data_type": "string"
+            }
+        ]
+    
+    @staticmethod    
+    def declare_outputs():
+        return [
+            {
+                "name": "s3_file_uri",
+                "data_type": "string",
+            }            
+        ]
+
+    @staticmethod
+    def get_default_file_name(file_url):
+        # Parse the URL into its components
+        path = urlparse(file_url).path
+        path_parts = os.path.split(path)
+
+        # Get the file name (the last part of the path)
+        file_name_with_extension = path_parts[-1]
+
+        # Split the file name into its name and extension
+        file_name, ext = os.path.splitext(file_name_with_extension)
+        return file_name
+
+    @staticmethod
+    def upload_to_s3(file_url, file_name, overwrite, s3_bucket, aws_credentials):
+        response = requests.get(file_url)
+
+        s3 = boto3.client('s3', 
+                        aws_access_key_id=aws_credentials['aws_access_key_id'], 
+                        aws_secret_access_key=aws_credentials['aws_secret_access_key'], 
+                        region_name=aws_credentials['aws_region_name'])
+
+        try:
+            s3.head_object(Bucket=s3_bucket, Key=file_name)
+            # If an exception is raised, the object exists
+            if not overwrite:
+                raise ValueError('Object already exists and overwrite is set to False')
+        except ClientError:
+            # If the object does not exist, head_object will raise a ClientError
+            pass
+
+        # Put object overwrites an existing object by default
+        s3.put_object(Body=response.content, Bucket=s3_bucket, Key=file_name)
+
+        # Return the S3 uri
+        return f"s3://{s3_bucket}/{file_name}"
+
+    def run_step(
+        self,
+        step,
+        ai_context: AiContext
+    ):
+        # Get AWS credentials
+        aws_credentials = {
+            'aws_access_key_id': ai_context.get_secret('aws_access_key_id'),
+            'aws_secret_access_key': ai_context.get_secret('aws_secret_access_key'),
+            'aws_region_name': ai_context.get_secret('aws_region_name')
+        }
+
+        # Parse inputs
+        file_url = ai_context.get_input('file_url', self)
+
+        # Parse parameters
+        p = step['parameters']
+
+        s3_bucket = p['s3_bucket']
+        overwrite = p.get('overwrite', False)
+        file_name = p.get('file_name')
+        if not file_name:
+            file_name = StoreInS3.get_default_file_name(file_url)
+
+        # Validation
+        if any(not value for value in aws_credentials.values()) or not s3_bucket:
+            raise ValueError('All AWS credentials and S3 bucket must be provided')
+
+        # Upload file to S3 and set output
+        s3_file_uri = StoreInS3.upload_to_s3(file_url, file_name, overwrite, s3_bucket, aws_credentials)
+
+        ai_context.set_output('s3_file_uri', s3_file_uri, self)
+        ai_context.add_to_log(f'Successfully saved file at {s3_file_uri}!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,10 @@ langchain
 pymupdf
 requests
 tabula-py
+tiktoken
+shortuuid
+spacy
+google-api-python-client
+google-cloud-storage
+botocore
+boto3

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -7,5 +7,6 @@ if [ -z "$OPENAI_TOKEN" ]; then
 fi
 
 pip install -r ./requirements.txt
+python -m spacy download en_core_web_sm
 
 python -m unittest discover

--- a/tests/test_store_in_s3.py
+++ b/tests/test_store_in_s3.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock, patch
+import unittest
+
+import sys
+from pathlib import Path
+# Add the parent directory of this package to PATH so that to 
+# make it possible to import other package from here, e.g. util
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from botocore.exceptions import ClientError
+
+from .mock_ai_context import MockAiContext
+from .tester import test_operator
+
+class StoreInS3Test(unittest.TestCase):
+    def test_store_in_s3(self):
+        # Mock the content that will be returned when the requests.get method is called
+        mock_response = Mock()
+        mock_response.content = b"file content"
+
+        # Mock the boto3 S3 client's methods
+        mock_s3 = Mock()
+        # Simulates a non-existing object
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "head_object"
+        )
+        # Simulates successful upload
+        mock_s3.put_object.return_value = None
+
+        store_in_s3_step = {
+            "operator": "Store in S3",
+            "parameters" : {
+                "file_name": "my_file.pdf",
+                "s3_bucket": "my_bucket",
+                "overwrite": False
+            }
+        }
+
+        all_tests = [
+            {
+                'step': store_in_s3_step,
+                'inputs': {
+                    'file_url': 'http://mockurl.com/my_file.pdf',
+                },
+                'expected_outputs': {
+                    's3_file_uri': 's3://my_bucket/my_file.pdf',
+                }
+            }
+        ]
+        
+        with patch('requests.get', return_value=mock_response), patch('boto3.client', return_value=mock_s3):
+            from operators import StoreInS3
+            test_operator(all_tests, StoreInS3, self)


### PR DESCRIPTION
- Added an operator to take in a file URL and store it in a specified AWS S3 bucket
- This operator relies on the addition of a few secrets: `aws_access_key_id`, `aws_secret_access_key`, `aws_region_name`
- These secrets could be used for accessing **any** AWS services on the account, S3 is just one specific usecase 
- These values must be exported as environment variables for the tests to pass similar to other secrets. Any string can be used as the AWS calls are mocked for the tests.
- The PR also includes some corrections to other files to get the `run_all_tests.sh` script to run correctly 