### PR TITLE
Fix typo StoreInDatabase --> StoreInDb

### DIFF
--- a/operators/store_in_db.py
+++ b/operators/store_in_db.py
@@ -77,7 +77,7 @@ class StoreInDb(BaseOperator):
         if p['split_by'] == 'line':
             chunks = text.splitlines()
         elif p['split_by'] == 'chunk':
-            chunks = StoreInDatabase.split_text_into_chunks(text, p['chunk_size_words'])
+            chunks = StoreInDb.split_text_into_chunks(text, p['chunk_size_words'])
         else:
             raise ValueError(f"Don't know what to do with value {p['split_by']} of parameter 'split_by'")
         


### PR DESCRIPTION
- I believe there was a typo in the `StoreInDb` operator, a static method in the class was being called with `StoreInDatabase` instead of `StoreInDb`.
- This PR corrects that