### PR TITLE
rss_to_json.py

### DIFF
--- a/rss_to_json.py
+++ b/rss_to_json.py
@@ -1,0 +1,57 @@
+import feedparser
+import json
+from .base_operator import BaseOperator
+from ai_context import AiContext
+
+class RSSToJsonOperator(BaseOperator):
+    @staticmethod
+    def declare_name():
+        return 'RSS To JSON Operator'
+
+    @staticmethod
+    def declare_description():
+        return 'This operator reads a URL as an RSS feed and outputs JSON with link and title.'
+
+    @staticmethod
+    def declare_category():
+        return BaseOperator.OperatorCategory.DATA_PROCESSING.value
+
+    @staticmethod
+    def declare_parameters():
+        return [
+            {
+                "name": "url",
+                "data_type": "string",
+                "placeholder": "Enter RSS feed URL",
+                "description": "The URL of the RSS feed to parse"
+            }
+        ]
+
+    @staticmethod
+    def declare_inputs():
+        return []
+
+    @staticmethod
+    def declare_outputs():
+        return [
+            {
+                "name": "output",
+                "data_type": "string",
+                "description": "The parsed RSS feed in JSON format"
+            }
+        ]
+
+    def run_step(self, step, ai_context):
+        p = step['parameters']
+        url = p['url']
+
+        # Parse the RSS feed
+        feed = feedparser.parse(url)
+
+        # Extract the link and title from each entry
+        output = [{'link': entry.link, 'title': entry.title} for entry in feed.entries]
+
+        # Convert the output to JSON
+        output_json = json.dumps(output)
+
+        ai_context.set_output('output', output_json, self)


### PR DESCRIPTION
This code contributes a new operator called "RSS To JSON Operator" that reads a URL as an RSS feed and outputs the parsed feed in JSON format. It takes a single parameter, "url", which is the URL of the RSS feed to parse. The operator has no inputs and outputs a single string output named "output" containing the parsed RSS feed in JSON format. The code uses the feedparser library to parse the RSS feed and extracts the link and title from each entry. It then converts the output to JSON using the json library and sets the JSON string as the output of the operator.